### PR TITLE
Add release files to support packer init

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+# This GitHub action can publish assets for release when a tag is created.
+# Currently its setup to run on any tag that matches the pattern "v*" (ie. v0.1.0).
+#
+# This uses an action (hashicorp/ghaction-import-gpg) that assumes you set your
+# private key in the `GPG_PRIVATE_KEY` secret and passphrase in the `PASSPHRASE`
+# secret. If you would rather own your own GPG handling, please fork this action
+# or use an alternative one for key handling.
+#
+# You will need to pass the `--batch` flag to `gpg` in your signing step
+# in `goreleaser` to indicate this is being used in a non-interactive mode.
+#
+name: release
+on:
+  push:
+    tags:
+      - 'v*'
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Unshallow
+        run: git fetch --prune --unshallow
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+      - name: Describe plugin
+        id: plugin_describe
+        run: echo "::set-output name=api_version::$(go run . describe | jq -r '.api_version')"
+      - name: Import GPG key
+        id: import_gpg
+        uses: hashicorp/ghaction-import-gpg@v2.1.0
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          API_VERSION: ${{ steps.plugin_describe.outputs.api_version }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,85 @@
+# This is an example goreleaser.yaml file with some defaults.
+# Make sure to check the documentation at http://goreleaser.com
+env:
+  - CGO_ENABLED=0
+before:
+  hooks:
+    # We strongly recommend running tests to catch any regression before release.
+    # Even though, this an optional step.
+    - go test ./...
+    # As part of the release doc files are included as a separate deliverable for
+    # consumption by Packer.io. To include a separate docs.zip uncomment the following command.
+    #- make ci-release-docs
+builds:
+  # A separated build to run the packer-plugins-check only once for a linux_amd64 binary
+  -
+    id: plugin-check
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    hooks:
+      post:
+        # This will check plugin compatibility against latest version of Packer
+        - cmd: |
+            go install github.com/hashicorp/packer/cmd/packer-plugins-check@latest &&
+            packer-plugins-check -load={{ .Name }}
+          dir: "{{ dir .Path}}"
+    flags:
+      - -trimpath #removes all file system paths from the compiled executable
+    ldflags:
+      - '-s -w -X {{ .ModulePath }}/version.Version={{.Version}} -X {{ .ModulePath }}/version.VersionPrerelease= '
+    goos:
+      - linux
+    goarch:
+      - amd64
+    binary: '{{ .ProjectName }}_v{{ .Version }}_{{ .Env.API_VERSION }}_{{ .Os }}_{{ .Arch }}'
+  -
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    flags:
+      - -trimpath #removes all file system paths from the compiled executable
+    ldflags:
+      - '-s -w -X {{ .ModulePath }}/version.Version={{.Version}} -X {{ .ModulePath }}/version.VersionPrerelease= '
+    goos:
+      - freebsd
+      - windows
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - '386'
+      - arm
+      - arm64
+    ignore:
+      - goos: darwin
+        goarch: '386'
+      - goos: linux
+        goarch: amd64
+    binary: '{{ .ProjectName }}_v{{ .Version }}_{{ .Env.API_VERSION }}_{{ .Os }}_{{ .Arch }}'
+archives:
+- format: zip
+  files:
+    - none*
+  name_template: '{{ .ProjectName }}_v{{ .Version }}_{{ .Env.API_VERSION }}_{{ .Os }}_{{ .Arch }}'
+checksum:
+  name_template: '{{ .ProjectName }}_v{{ .Version }}_SHA256SUMS'
+  algorithm: sha256
+signs:
+  - artifacts: checksum
+    args:
+      # if you are using this is in a GitHub action or some other automated pipeline, you
+      # need to pass the batch flag to indicate its not interactive.
+      - "--batch"
+      - "--local-user"
+      - "{{ .Env.GPG_FINGERPRINT }}"
+      - "--output"
+      - "${signature}"
+      - "--detach-sign"
+      - "${artifact}"
+release:
+  # If you want to manually examine the release before its live, uncomment this line:
+  # draft: true
+  # As part of the release doc files are included as a separate deliverable for consumption by Packer.io.
+  # To include a separate docs.zip uncomment the extra_files config and the docs.zip command hook above.
+  #extra_files:
+  #- glob: ./docs.zip
+
+changelog:
+  skip: true


### PR DESCRIPTION
## Pull Request 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ X ] Build related changes
- [ ] Documentation content changes
- [ ] Other: (describe here) 
  
## Proposed Change
Following the packer guide for releasing changes, https://www.packer.io/docs/plugins/creation#creating-a-github-release
This is related to #73 

The veertu team will need to follow the release guide above to add a gpg key and passphrase to the repository's secrets 

I was able to verify that this works within my fork of the plugin using the hcl block 
```packer {
  required_plugins {
    veertu-anka = {
      version = ">= v2.0.0"
      source = "github.com/jamesforsee/veertu-anka"
    }
  }
}
```
A release is then automatically created whenever a tag with the semantic versioning format is push (e.g. v1.2.3) 

## Breaking Change?

- [ ] Yes
- [ X ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications here -->

## Checklist

Please validate that your PR fulfills the following requirements:
- [ ] I have read the **CONTRIBUTING.md** documentation
- [ ] I have branched from the master branch
- [ ] I have checked that a similar PR does not exist or has been rejected in the past
- [ ] PR changes are specific to a feature or bug
- [ ] No style/format/cosmetic changes included
- [ ] I have used existing style and naming patterns in my changes
- [ ] Tests for the changes have been added/updated (if relevant)
- [ ] Built/compiled and tested locally
- [ ] Docs have been added/updated (if relevant)
- [ ] I have squashed my changes into a single commit


## Additional Information
<!-- Any other information that is important to this PR such as screenshots of how the feature/bug looked before and after the change. -->