### PR TITLE
Update post-processor to provide nicer feedback

### DIFF
--- a/post-processor/ankaregistry/post-processor.go
+++ b/post-processor/ankaregistry/post-processor.go
@@ -65,6 +65,10 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 		return fmt.Errorf("You must specify a valid tag for your Veertu Anka VM (e.g. 'latest')")
 	}
 
+	if p.config.Local && p.config.RemoteVM != "" {
+		return fmt.Errorf("The 'local' and 'remote_vm' settings are mutually exclusive.")
+	}
+
 	p.client = &client.AnkaClient{}
 
 	return nil

--- a/post-processor/ankaregistry/post-processor.go
+++ b/post-processor/ankaregistry/post-processor.go
@@ -152,7 +152,12 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packer.Ui, artifact 
 		}
 	}
 
-	ui.Say(fmt.Sprintf("Pushing template to Anka Registry as %s with tag %s", remoteVMName, remoteTag))
+	if p.config.Local {
+		ui.Say(fmt.Sprintf("Tagging local template %s with tag %s", remoteVMName, remoteTag))
+	} else {
+		ui.Say(fmt.Sprintf("Pushing template to Anka Registry as %s with tag %s", remoteVMName, remoteTag))
+	}
+
 	pushErr := p.client.RegistryPush(registryParams, pushParams)
 
 	return artifact, true, false, pushErr


### PR DESCRIPTION
* Error out more quickly if `local` and `remote_vm` are specified together. 
* Provide clearer feedback when performing local-only registry action(s). 

Signed-off-by: Tom Duffield <github@tomduffield.com>