### PR TITLE
Check the length of slice before to refer to a missing index

### DIFF
--- a/client/client_registry.go
+++ b/client/client_registry.go
@@ -102,6 +102,7 @@ func (c *AnkaClient) RegistryListRepos() (RegistryListReposResponse, error) {
 func (c *AnkaClient) RegistryListReposArm64() (RegistryListReposResponse, error) {
 	var response RegistryListReposResponse
 	var responseArm64 RegistryListReposResponseArm64
+	var port string
 
 	output, err := runRegistryCommand(RegistryParams{}, "list-repos")
 	if err != nil {
@@ -125,11 +126,14 @@ func (c *AnkaClient) RegistryListReposArm64() (RegistryListReposResponse, error)
 		}
 
 		s := strings.Split(u.Host, ":")
+		if len(s) == 2 {
+			port = s[1]
+		}
 		a := RegistryRemote{
 			Scheme:  u.Scheme,
 			Default: remote.Default,
 			Host:    s[0],
-			Port:    s[1],
+			Port:    port,
 		}
 		tmpBody[remote.Name] = a
 	}


### PR DESCRIPTION
## Pull Request 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other: (describe here) 
  
## Proposed Change
<!-- Explain your change, its motivation, compare previous and new behaviour and link to issue, if exists -->
It solves the bug introduced by #114. The current code assumes registry defined as `<fqdn>:<port>`, but `<port>` may be omitted if the standard protocol port is used. The current test passes because testdata has `<port>` defined.

### NOTE
This bug impact only M1 hosts.

## Current Post-Processor behavior
Currently Packer builds correctly but crashes on `post-processor`.
```
Post-processor failed: unexpected EOF"}
 ```


<!-- Write your answer here -->

## Breaking Change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications here -->

## Checklist

Please validate that your PR fulfills the following requirements:
- [x] I have read the **CONTRIBUTING.md** documentation (if available)
- [x] I have branched from the default repo branch (can be master, main, or release/vX.X)
- [x] I have checked that a similar PR does not exist or has been rejected in the past
- [x] PR changes are specific to a feature or bug
- [x] No style/format/cosmetic changes included
- [x] I have used existing style and naming patterns in my changes
- [ ] Tests for the changes have been added/updated (if relevant)
- [ ] Built/compiled and tested locally
- [ ] Docs have been added/updated (if relevant)
- [ ] I have squashed my changes into a single commit


## Additional Information
<!-- Any other information that is important to this PR such as screenshots of how the feature/bug looked before and after the change. -->
