### PR TITLE
Support display_resolution parameter for creating and cloning templates

### DIFF
--- a/builder/anka/config.go
+++ b/builder/anka/config.go
@@ -61,6 +61,7 @@ type Config struct {
 	BootDelay         string `mapstructure:"boot_delay"`
 	UseAnkaCP         bool   `mapstructure:"use_anka_cp"`
 	DisplayController string `mapstructure:"display_controller,omitempty"`
+	DisplayResolution string `mapstructure:"display_resolution,omitempty"`
 
 	StopVM bool `mapstructure:"stop_vm"`
 

--- a/builder/anka/step_clone_vm.go
+++ b/builder/anka/step_clone_vm.go
@@ -330,5 +330,17 @@ func (s *StepCloneVM) modifyVMProperties(showResponse client.ShowResponse, confi
 		}
 	}
 
+	if config.DisplayResolution != "" {
+		err := s.client.Stop(stopParams)
+		if err != nil {
+			return err
+		}
+		ui.Say(fmt.Sprintf("Modifying VM display resolution to %s", config.DisplayResolution))
+		err = s.client.Modify(showResponse.Name, "set", "display", "-r", config.DisplayResolution)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/builder/anka/step_create_vm.go
+++ b/builder/anka/step_create_vm.go
@@ -185,6 +185,18 @@ func (s *StepCreateVM) modifyVMProperties(showResponse client.ShowResponse, conf
 		}
 	}
 
+	if config.DisplayResolution != "" {
+		err := s.client.Stop(stopParams)
+		if err != nil {
+			return err
+		}
+		ui.Say(fmt.Sprintf("Modifying VM display resolution to %s", config.DisplayResolution))
+		err = s.client.Modify(showResponse.Name, "set", "display", "-r", config.DisplayResolution)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/builder/anka/step_create_vm_test.go
+++ b/builder/anka/step_create_vm_test.go
@@ -280,7 +280,8 @@ func TestCreateVMRun(t *testing.T) {
 				"RAMSize":   "16G",
 				"Installer": "latest",
 				"HWUUID": "abcdefgh",
-				"DisplayController": "pg"
+				"DisplayController": "pg",
+				"DisplayResolution": "1920x1080"
 			}
 		`), &config)
 		if err != nil {
@@ -323,6 +324,8 @@ func TestCreateVMRun(t *testing.T) {
 			ankaClient.EXPECT().Modify(createdShowResponse.Name, "set", "custom-variable", "hw.uuid", config.HWUUID).Return(nil).Times(1),
 			ankaClient.EXPECT().Stop(stopParams).Return(nil).Times(1),
 			ankaClient.EXPECT().Modify(createdShowResponse.Name, "set", "display", "-c", config.DisplayController).Return(nil).Times(1),
+			ankaClient.EXPECT().Stop(stopParams).Return(nil).Times(1),
+			ankaClient.EXPECT().Modify(createdShowResponse.Name, "set", "display", "-r", config.DisplayResolution).Return(nil).Times(1),
 		)
 
 		mockui := packer.MockUi{}
@@ -331,6 +334,7 @@ func TestCreateVMRun(t *testing.T) {
 		mockui.Say(fmt.Sprintf("Ensuring %s port-forwarding (Guest Port: %s, Host Port: %s, Rule Name: %s)", createdShowResponse.Name, strconv.Itoa(config.PortForwardingRules[0].PortForwardingGuestPort), strconv.Itoa(config.PortForwardingRules[0].PortForwardingHostPort), config.PortForwardingRules[0].PortForwardingRuleName))
 		mockui.Say(fmt.Sprintf("Modifying VM custom-variable hw.uuid to %s", config.HWUUID))
 		mockui.Say(fmt.Sprintf("Modifying VM display controller to %s", config.DisplayController))
+		mockui.Say(fmt.Sprintf("Modifying VM display resolution to %s", config.DisplayResolution))
 
 		stepAction := step.Run(ctx, state)
 		assert.Equal(t, mockui.SayMessages[0].Message, "Creating a new VM Template (anka-packer-base-latest) from installer, this will take a while")


### PR DESCRIPTION
## Pull Request 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other: (describe here) 
  
## Proposed Change
As a developer using the create and clone sources, I'd like to be able to define the screen resolution as part of my packer configuration rather than using a `shell-local` provisioner.

## Breaking Change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications here -->

## Checklist

Please validate that your PR fulfills the following requirements:
- [x] I have read the **CONTRIBUTING.md** documentation (if available)
- [x] I have branched from the default repo branch (can be master, main, or release/vX.X)
- [x] I have checked that a similar PR does not exist or has been rejected in the past
- [x] PR changes are specific to a feature or bug
- [x] No style/format/cosmetic changes included
- [x] I have used existing style and naming patterns in my changes
- [x] Tests for the changes have been added/updated (if relevant)
- [ ] Built/compiled and tested locally
- [x] Docs have been added/updated (if relevant)
- [x] I have squashed my changes into a single commit


## Additional Information
I was able to run the tests I modified locally via VSCode's Go plugin but the `make all` command [in the README](https://github.com/veertuinc/packer-plugin-veertu-anka?tab=readme-ov-file#building-linting-and-testing) fails for me locally. I can post the whole log if needed but it seems to stem from the post-processor tests:
```
go test -v post-processor/ankaregistry/*.go
    │ # command-line-arguments
    │ # [command-line-arguments]
    │ post-processor/ankaregistry/post-processor.go:199:20: non-constant format string in call to fmt.Errorf
```

I didn't touch the post-processor so I'm a bit confused by this but I am NOT a Go programmer so it is quite possible that I've missed or misunderstood something.